### PR TITLE
macOS: update library name with lib prefix

### DIFF
--- a/build/osx/Makefile
+++ b/build/osx/Makefile
@@ -6,7 +6,7 @@ SRC_DIR=../../src
 CC= gcc
 ARCH_FLAGS= -m32
 CFLAGS= $(ARCH_FLAGS) -Wall -Wextra -O2 -I$(SRC_DIR)
-LIBNAME=empty-pkcs11-x86.dylib
+LIBNAME=libempty-pkcs11-x86.dylib
 
 all: empty-pkcs11.o
 	$(CC) $(ARCH_FLAGS) -dynamiclib -o $(LIBNAME) \

--- a/build/osx/build.sh
+++ b/build/osx/build.sh
@@ -4,12 +4,12 @@ set -e
 
 make distclean
 
-cat Makefile | sed 's/^ARCH_FLAGS=.*/ARCH_FLAGS= -m32/' | sed 's/^LIBNAME=.*/LIBNAME=empty-pkcs11-x86.dylib/' > Makefile.x86
+cat Makefile | sed 's/^ARCH_FLAGS=.*/ARCH_FLAGS= -m32/' | sed 's/^LIBNAME=.*/LIBNAME=libempty-pkcs11-x86.dylib/' > Makefile.x86
 make -f Makefile.x86
 rm Makefile.x86
 make clean
 
-cat Makefile | sed 's/^ARCH_FLAGS=.*/ARCH_FLAGS= -m64/' | sed 's/^LIBNAME=.*/LIBNAME=empty-pkcs11-x64.dylib/' > Makefile.x64
+cat Makefile | sed 's/^ARCH_FLAGS=.*/ARCH_FLAGS= -m64/' | sed 's/^LIBNAME=.*/LIBNAME=libempty-pkcs11-x64.dylib/' > Makefile.x64
 make -f Makefile.x64
 rm Makefile.x64
 make clean


### PR DESCRIPTION
The latest dotnet6-macos has an issue where the library can't be
linked if it doesn't start with `lib`. This PR mitigates that issue.