### PR TITLE
make GetInterface() return CKR_ARGUMENTS_BAD when it cannot get interface

### DIFF
--- a/src/empty-pkcs11.c
+++ b/src/empty-pkcs11.c
@@ -961,7 +961,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetInterface)(CK_UTF8CHAR_PTR pInterfaceName, CK_VER
 	if (flags != 0)
 	{
 		*ppInterface = NULL;
-		return CKR_OK;
+		return CKR_ARGUMENTS_BAD;
 	}
 
 	if (NULL != pInterfaceName)
@@ -972,7 +972,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetInterface)(CK_UTF8CHAR_PTR pInterfaceName, CK_VER
 		if (strlen(requested_interface_name) != strlen(supported_interface_name) || 0 != strcmp(requested_interface_name, supported_interface_name))
 		{
 			*ppInterface = NULL;
-			return CKR_OK;
+			return CKR_ARGUMENTS_BAD;
 		}
 	}
 
@@ -991,7 +991,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetInterface)(CK_UTF8CHAR_PTR pInterfaceName, CK_VER
 		else
 		{
 			*ppInterface = NULL;
-			return CKR_OK;
+			return CKR_ARGUMENTS_BAD;
 		}
 	}
 


### PR DESCRIPTION
Hey ! I was playing around with your repository, and trying to add it to Firefox NSS (`modutil -dbdir sql:$HOME/.mozilla/firefox/0mv0v2fp.dev-edition-default  -add "MyPKCS11" -libfile $(realpath empty-pkcs11-x64.so)`), and noticed that I couldn't (segmentation fault on NSS's part because `interface` was null)

After debugging, I found out that NSS [expects something else than](https://github.com/nss-dev/nss/blob/63eda558c33409db96af0b83400b93193187abaf/lib/pk11wrap/pk11load.c#L516-L517) `CKR_OK` to be returned when GetInterface() fails. This PR fixes this, so the module can be added to NSS (It still cannot because GetInfo is unimplemented, but this is probably intended for this repository)
